### PR TITLE
Update branches and checkouts

### DIFF
--- a/buildout.d/sources.cfg
+++ b/buildout.d/sources.cfg
@@ -29,7 +29,7 @@ lmu.contenttypes.polls         = git https://github.com/lmu/lmu.contenttypes.pol
 Products.ZopeHealthWatcher     = git https://github.com/loechel/Products.ZopeHealthWatcher.git  pushurl=git@github.com:loechel/Products.ZopeHealthWatcher.git
 plone.namedfile                = git https://github.com/plone/plone.namedfile.git               pushurl=git@github.com:plone/plone.namedfile.git               branch=allow-easier-customization
 wildcard.foldercontents        = git https://github.com/collective/wildcard.foldercontents.git  pushurl=git@github.com:collective/wildcard.foldercontents.git
-plone.app.discussion           = git https://github.com/plone/plone.app.discussion.git          pushurl=git@github.com:plone/plone.app.discussion.git          branch=permission-fix-2.2.x-for_plone4-and-notify-modified
+plone.app.discussion           = git https://github.com/plone/plone.app.discussion.git          pushurl=git@github.com:plone/plone.app.discussion.git          branch=permission-fix-2.2.x-for_plone4
 collective.quickupload         = git https://github.com/collective/collective.quickupload.git   pushurl=git@github.com:collective/collective.quickupload.git
 plone.versioncheck             = git https://github.com/plone/plone.versioncheck.git            pushurl=git@github.com:plone/plone.versioncheck.git            branch=master
 

--- a/buildout.d/sources.cfg
+++ b/buildout.d/sources.cfg
@@ -16,12 +16,12 @@
 ############################################
 
 # LMU Specific Packages
-lmu.policy.base                = git https://github.com/lmu/lmu.policy.base.git            pushurl=git@github.com:lmu/lmu.policy.base.git           branch=rich-comments
+lmu.policy.base                = git https://github.com/lmu/lmu.policy.base.git            pushurl=git@github.com:lmu/lmu.policy.base.git
 lmu.policy.serviceportal       = git https://github.com/lmu/lmu.policy.serviceportal.git   pushurl=git@github.com:lmu/lmu.policy.serviceportal.git
 lmu.policy.intranet            = git https://github.com/lmu/lmu.policy.intranet.git        pushurl=git@github.com:lmu/lmu.policy.intranet.git
 lmu.theme.intranet             = git https://github.com/lmu/lmu.theme.intranet.git         pushurl=git@github.com:lmu/lmu.theme.intranet.git
 lmu.theme.serviceportal        = git https://github.com/lmu/lmu.theme.serviceportal.git    pushurl=git@github.com:lmu/lmu.theme.serviceportal.git
-lmu.contenttypes.blog          = git https://github.com/lmu/lmu.contenttypes.blog.git      pushurl=git@github.com:lmu/lmu.contenttypes.blog.git     branch=video-thumbnail
+lmu.contenttypes.blog          = git https://github.com/lmu/lmu.contenttypes.blog.git      pushurl=git@github.com:lmu/lmu.contenttypes.blog.git
 lmu.contenttypes.pinnwand      = git https://github.com/lmu/lmu.contenttypes.pinnwand.git  pushurl=git@github.com:lmu/lmu.contenttypes.pinnwand.git
 lmu.contenttypes.polls         = git https://github.com/lmu/lmu.contenttypes.polls.git     pushurl=git@github.com:lmu/lmu.contenttypes.polls.git
 

--- a/buildout.d/sources.cfg
+++ b/buildout.d/sources.cfg
@@ -16,20 +16,20 @@
 ############################################
 
 # LMU Specific Packages
-lmu.policy.base                = git https://github.com/lmu/lmu.policy.base.git            pushurl=git@github.com:lmu/lmu.policy.base.git
+lmu.policy.base                = git https://github.com/lmu/lmu.policy.base.git            pushurl=git@github.com:lmu/lmu.policy.base.git           branch=rich-comments
 lmu.policy.serviceportal       = git https://github.com/lmu/lmu.policy.serviceportal.git   pushurl=git@github.com:lmu/lmu.policy.serviceportal.git
 lmu.policy.intranet            = git https://github.com/lmu/lmu.policy.intranet.git        pushurl=git@github.com:lmu/lmu.policy.intranet.git
 lmu.theme.intranet             = git https://github.com/lmu/lmu.theme.intranet.git         pushurl=git@github.com:lmu/lmu.theme.intranet.git
 lmu.theme.serviceportal        = git https://github.com/lmu/lmu.theme.serviceportal.git    pushurl=git@github.com:lmu/lmu.theme.serviceportal.git
-lmu.contenttypes.blog          = git https://github.com/lmu/lmu.contenttypes.blog.git      pushurl=git@github.com:lmu/lmu.contenttypes.blog.git
+lmu.contenttypes.blog          = git https://github.com/lmu/lmu.contenttypes.blog.git      pushurl=git@github.com:lmu/lmu.contenttypes.blog.git     branch=video-thumbnail
 lmu.contenttypes.pinnwand      = git https://github.com/lmu/lmu.contenttypes.pinnwand.git  pushurl=git@github.com:lmu/lmu.contenttypes.pinnwand.git
 lmu.contenttypes.polls         = git https://github.com/lmu/lmu.contenttypes.polls.git     pushurl=git@github.com:lmu/lmu.contenttypes.polls.git
 
 # Generic Packages where current release state did not match requirements / implementations state or generic modification are necessary
 Products.ZopeHealthWatcher     = git https://github.com/loechel/Products.ZopeHealthWatcher.git  pushurl=git@github.com:loechel/Products.ZopeHealthWatcher.git
-#plone.namedfile                = git https://github.com/plone/plone.namedfile.git               pushurl=git@github.com:plone/plone.namedfile.git               branch=master
+plone.namedfile                = git https://github.com/plone/plone.namedfile.git               pushurl=git@github.com:plone/plone.namedfile.git               branch=allow-easier-customization
 wildcard.foldercontents        = git https://github.com/collective/wildcard.foldercontents.git  pushurl=git@github.com:collective/wildcard.foldercontents.git
-plone.app.discussion           = git https://github.com/plone/plone.app.discussion.git          pushurl=git@github.com:plone/plone.app.discussion.git          branch=permission-fix-2.2.x-for_plone4
+plone.app.discussion           = git https://github.com/plone/plone.app.discussion.git          pushurl=git@github.com:plone/plone.app.discussion.git          branch=permission-fix-2.2.x-for_plone4-and-notify-modified
 collective.quickupload         = git https://github.com/collective/collective.quickupload.git   pushurl=git@github.com:collective/collective.quickupload.git
 plone.versioncheck             = git https://github.com/plone/plone.versioncheck.git            pushurl=git@github.com:plone/plone.versioncheck.git            branch=master
 


### PR DESCRIPTION
I reverted the lmu.policy.base and lmu.contenttypes.blog checkout to master, as we should have merged them already.

So we have two other changed branches in plone.namedfile and plone.app.discussion